### PR TITLE
Fixes icon height when SSR is enabled. Closes #2

### DIFF
--- a/src/runtime/components/MdiIcon.vue
+++ b/src/runtime/components/MdiIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    viewbox="0 0 24 24"
+    viewBox="0 0 24 24"
     :style="styles"
   >
     <path :d="path" />


### PR DESCRIPTION
There was typo in `viewbox`. It should be `viewBox` (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox)