### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Add 7,000+ icons to your Nuxt project, from [Material Design Icons](https://pict
 Install the `nuxt-mdi` dependency to your project using your preferred package manager:
 
 ```bash
-pnpm add -D nuxt-mdi
+npx nuxi@latest module add nuxt-mdi
 ```
 ```bash
-yarn add --dev nuxt-mdi
+npx nuxi@latest module add nuxt-mdi
 ```
 ```bash
-npm install --save-dev nuxt-mdi
+npx nuxi@latest module add nuxt-mdi
 ```
 
 ### Activation

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -35,7 +35,7 @@ Add 7,000+ icons to your Nuxt application, from [Material Design Icons](https://
   ::terminal
   ---
   content:
-  - npm install --dev nuxt-mdi
+  - npx nuxi@latest module add nuxt-mdi
   ---
   ::
 ::

--- a/docs/content/1.introduction/1.getting-started.md
+++ b/docs/content/1.introduction/1.getting-started.md
@@ -11,22 +11,9 @@ You can start playing with Docus in your browser using Stackblitz:
 ## Installation
 
 1. Install the `nuxt-mdi` dependency to your project using your preferred package manager:
-
-::code-group
-
-  ```bash [npm]
-  npm install --save-dev nuxt-mdi
-  ```
-
-  ```bash [yarn]
-  yarn add -D nuxt-mdi
-  ```
-
-  ```bash [pnpm]
-  pnpm add -D nuxt-mdi
-  ```
-
-::
+```bash
+npx nuxi@latest module add nuxt-mdi
+```
 
 2. Add `'nuxt-mdi'` to the modules section of your `nuxt.config.ts` file.
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
