### PR TITLE
MdiIcon.vue : make type imports explicit

### DIFF
--- a/src/runtime/components/MdiIcon.vue
+++ b/src/runtime/components/MdiIcon.vue
@@ -9,8 +9,9 @@
 
 <script setup lang="ts">
 import { importIcon } from '../library/loader'
-import { Ref, ComputedRef, computed, ref, watch } from 'vue'
-import { MdiIconString } from './MdiIcon'
+import type { Ref, ComputedRef} from 'vue'
+import { computed, ref, watch } from 'vue'
+import type { MdiIconString } from './MdiIcon'
 
 export interface MdiIconProps {
   width?: string,

--- a/src/runtime/components/MdiIcon.vue
+++ b/src/runtime/components/MdiIcon.vue
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import { importIcon } from '../library/loader'
-import type { Ref, ComputedRef} from 'vue'
+import type { Ref, ComputedRef } from 'vue'
 import { computed, ref, watch } from 'vue'
 import type { MdiIconString } from './MdiIcon'
 


### PR DESCRIPTION
Making type imports explicit is a ts best practice and necessary when verbatimModuleSyntax is enabled