### PR TITLE
Update MdiIcon.vue

### DIFF
--- a/src/runtime/components/MdiIcon.vue
+++ b/src/runtime/components/MdiIcon.vue
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<MdiIconProps>(), {
   size: undefined,
   flipX: false,
   flipY: false,
-  preserveAspectRatio: 'meet',
+  preserveAspectRatio: 'xMidYMid meet',
 })
 
 const _size = computed(() => {


### PR DESCRIPTION
Fix for "Error: <svg> attribute preserveAspectRatio: Unrecognized enumerated value, "meet"."